### PR TITLE
Extra steps for cleaning build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -120,7 +120,7 @@ echo "Keeping files: ${whitelist[@]}"
 
 local_files=( $(ls .) )
 for file in ${local_files[@]}; do
-  if [[ $(in_array "(full_path ${file})" ${whitelist[@]}) == "true" ]]; then
+  if [[ $(in_array "$(full_path ${file})" ${whitelist[@]}) == "true" ]]; then
     echo "Skipping ${file}" | indent
   else
     if [[ -d ${file} ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -118,7 +118,7 @@ echo "Keeping files: ${files_to_keep[@]}"
 for file in $(ls)
 do
 	echo "Testing $(full_path "${file}")"
-  if in_array "${file}" ${files_to_keep[@]}; then
+  if in_array "(full_path ${file})" ${files_to_keep[@]}; then
     echo "Skipping ${file}" | indent
   else
     if [[ -d ${file} ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -110,7 +110,7 @@ echo "Doing an extra deep clean before slugifying" | indent
 # Loop through each file / directory and delete everythign not on the whitelist
 for file in $(ls)
 do
-  if [[ in_array "${file}" $files_to_keep ]]; then
+  if [[ $(in_array "${file}" $files_to_keep) -ne 1 ]]; then
     echo "Keeping removing ${file}" | indent
   else
     if [[ -d ${file} ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -104,8 +104,12 @@ cleanup_dotnet $BUILD_DIR
 cp ${PROCFILE_PATH} ${BUILD_DIR}/Procfile
 echo "Using Procfile specified by PROCFILE_PATH: $PROCFILE_PATH" | indent
 
+function full_path() {
+	echo "$(pwd -P)/$(basename $1)"
+}
+
 # Whitelist of files to retain
-files_to_keep=("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" "Procfile")
+files_to_keep=("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" $(full_path "Procfile"))
 echo "Doing an extra deep clean before slugifying"
 # Loop through each file / directory and delete everythign not on the whitelist
 
@@ -113,9 +117,9 @@ echo "Keeping files: ${files_to_keep[@]}"
 
 for file in $(ls)
 do
-	echo "Testing ${file}"
-  if in_array "${file}" $files_to_keep; then
-    echo "Keeping ${file}" | indent
+	echo "Testing $(full_path "${file}")"
+  if in_array "${file}" ${files_to_keep[@]}; then
+    echo "Skipping ${file}" | indent
   else
     if [[ -d ${file} ]]; then
       echo "Removing directory ${file}" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -104,21 +104,23 @@ cleanup_dotnet $BUILD_DIR
 cp ${PROCFILE_PATH} ${BUILD_DIR}/Procfile
 echo "Using Procfile specified by PROCFILE_PATH: $PROCFILE_PATH" | indent
 
-function full_path() {
-	echo "$(pwd -P)/$(basename $1)"
-}
+echo "Doing an extra deep clean before slugifying"
 
 # Whitelist of files to retain
-files_to_keep=("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" $(full_path "Procfile"))
-echo "Doing an extra deep clean before slugifying"
+whitelist=(
+	"${OUTPUT_DIR}"
+	"${CACHE_DIR}"
+	"${ENV_DIR}"
+	"$(full_path "Procfile")"
+)
+
 # Loop through each file / directory and delete everythign not on the whitelist
 
-echo "Keeping files: ${files_to_keep[@]}" 
+echo "Keeping files: ${whitelist[@]}"
 
-for file in $(ls)
-do
-	echo "Testing $(full_path "${file}")"
-  if in_array "(full_path ${file})" ${files_to_keep[@]}; then
+local_files=( $(ls .) )
+for file in ${local_files[@]}; do
+  if [[ $(in_array "(full_path ${file})" ${whitelist[@]}) == "true" ]]; then
     echo "Skipping ${file}" | indent
   else
     if [[ -d ${file} ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -106,12 +106,16 @@ echo "Using Procfile specified by PROCFILE_PATH: $PROCFILE_PATH" | indent
 
 # Whitelist of files to retain
 files_to_keep=("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" "Procfile")
-echo "Doing an extra deep clean before slugifying" | indent
+echo "Doing an extra deep clean before slugifying"
 # Loop through each file / directory and delete everythign not on the whitelist
+
+echo "Keeping files: ${files_to_keep[@]}" 
+
 for file in $(ls)
 do
+	echo "Testing ${file}"
   if in_array "${file}" $files_to_keep; then
-    echo "Keeping removing ${file}" | indent
+    echo "Keeping ${file}" | indent
   else
     if [[ -d ${file} ]]; then
       echo "Removing directory ${file}" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,7 @@ export NUGET_XMLDOC_MODE=${NUGET_XMLDOC_MODE:-skip}
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=${DOTNET_SKIP_FIRST_TIME_EXPERIENCE:-1}
 export DOTNET_CLI_TELEMETRY_OPTOUT=${DOTNET_CLI_TELEMETRY_OPTOUT:-1}
 
+OUTPUT_DIR="${BUILD_DIR}/heroku_output"
 DOTNET_SDK_VERSION=${DOTNET_SDK_VERSION:-3.1.410}
 DOTNET_RUNTIME_VERSION=${DOTNET_RUNTIME_VERSION:-3.1.16}
 BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-Release}
@@ -79,8 +80,8 @@ if [ ${BUILD_PUBLISH:-true} = "true" ]; then
 	do
 		PROJECT_NAME=$(basename ${proj%.*})
 
-		echo "dotnet publish $proj --output ${BUILD_DIR}/heroku_output/${PROJECT_NAME} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64"
-		dotnet publish $proj --output ${BUILD_DIR}/heroku_output/${PROJECT_NAME} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
+		echo "dotnet publish $proj --output ${OUTPUT_DIR}/${PROJECT_NAME} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64"
+		dotnet publish $proj --output ${OUTPUT_DIR}/${PROJECT_NAME} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
 	done
 fi
 
@@ -102,3 +103,22 @@ cleanup_dotnet $BUILD_DIR
 
 cp ${PROCFILE_PATH} ${BUILD_DIR}/Procfile
 echo "Using Procfile specified by PROCFILE_PATH: $PROCFILE_PATH" | indent
+
+# Whitelist of files to retain
+files_to_keep = ("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" "Procfile")
+echo "Doing an extra deep clean before slugifying" | indent
+# Loop through each file / directory and delete everythign not on the whitelist
+for file in $(ls)
+do
+  if [[ in_array "${file}" $files_to_keep ]]; then
+    echo "Keeping removing ${file}" | indent
+  else
+    if [[ -d ${file} ]]; then
+      echo "Removing directory ${file}" | indent
+      rm -fR ${file}
+    else
+      echo "Removing file ${file}" | indent
+      rm ${file}
+    fi
+  fi
+done

--- a/bin/compile
+++ b/bin/compile
@@ -105,7 +105,7 @@ cp ${PROCFILE_PATH} ${BUILD_DIR}/Procfile
 echo "Using Procfile specified by PROCFILE_PATH: $PROCFILE_PATH" | indent
 
 # Whitelist of files to retain
-files_to_keep = ("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" "Procfile")
+files_to_keep=("${OUTPUT_DIR}" "${CACHE_DIR}" "${ENV_DIR}" "Procfile")
 echo "Doing an extra deep clean before slugifying" | indent
 # Loop through each file / directory and delete everythign not on the whitelist
 for file in $(ls)

--- a/bin/compile
+++ b/bin/compile
@@ -110,7 +110,7 @@ echo "Doing an extra deep clean before slugifying" | indent
 # Loop through each file / directory and delete everythign not on the whitelist
 for file in $(ls)
 do
-  if [[ $(in_array "${file}" $files_to_keep) -ne 1 ]]; then
+  if in_array "${file}" $files_to_keep; then
     echo "Keeping removing ${file}" | indent
   else
     if [[ -d ${file} ]]; then

--- a/lib/utils
+++ b/lib/utils
@@ -79,9 +79,6 @@ function cleanup_dotnet() {
 # Checks if an item is in an array
 # usage: in_array "needle" ("this is a haystack" "needle")
 function in_array() {
-  local needle="$1" arr="$2[@]" item
-  for item in "${!arr}"; do
-    [[ "${item}" == "${needle}" ]] && return 0
-  done
+  for item in "${@:2}"; do [[ "$item" == "$1" ]] && return 0; done
   return 1
 }

--- a/lib/utils
+++ b/lib/utils
@@ -76,6 +76,10 @@ function cleanup_dotnet() {
   rm -rf ${BUILD_DIR}/.heroku/dotnet-sdk
 }
 
+function full_path() {
+  echo "$(pwd -P)/$(basename $1)"
+}
+
 # Checks if an item is in an array
 # usage: in_array "needle" ("this is a haystack" "needle")
 function in_array() {
@@ -83,6 +87,7 @@ function in_array() {
   shift
   local haystack=$@
 
-  for element_ in ${haystack[@]}; do [[ "$needle" == "$element_" ]] && return 0; done
+  for element_ in ${haystack[@]}; do [[ "$needle" == "$element_" ]] && echo "true" && return 0; done
+  echo "false"
   return 1
 }

--- a/lib/utils
+++ b/lib/utils
@@ -75,3 +75,13 @@ function cleanup_dotnet() {
   rm -rf ${BUILD_DIR}/.heroku/dotnet
   rm -rf ${BUILD_DIR}/.heroku/dotnet-sdk
 }
+
+# Checks if an item is in an array
+# usage: in_array "needle" ("this is a haystack" "needle")
+function in_array() {
+  local needle="$1" arr="$2[@]" item
+  for item in "${!arr}"; do
+    [[ "${item}" == "${needle}" ]] && return 0
+  done
+  return 1
+}

--- a/lib/utils
+++ b/lib/utils
@@ -79,6 +79,10 @@ function cleanup_dotnet() {
 # Checks if an item is in an array
 # usage: in_array "needle" ("this is a haystack" "needle")
 function in_array() {
-  for item in "${@:2}"; do [[ "$item" == "$1" ]] && return 0; done
+  local needle=$1
+  shift
+  local haystack=$@
+
+  for element_ in ${haystack[@]}; do [[ "$needle" == "$element_" ]] && return 0; done
   return 1
 }


### PR DESCRIPTION
Adds a bit more to the compile step that removes everything not on a whitelist from the image.

Example results:

```
Cleanup dotnet SDK
       Using Procfile specified by PROCFILE_PATH: /tmp/build_3131ab61/Procfile.messaging
Doing an extra deep clean before slugifying
Keeping files: /tmp/build_3131ab61/heroku_output /tmp/codon/tmp/cache /tmp/d20210712-56-9qwqdh /tmp/build_3131ab61/Procfile
       Removing file app.json
       Removing directory assets
       Removing file babel.config.js
       Removing directory client
       Removing file docker-compose.yml
       Removing file heroku-buildpack-features
       Skipping heroku_output
       Removing file index.d.ts
       Removing file jest.config.js
       Removing file package.json
       Removing file postcss.config.js
       Removing directory postgresql
       Removing file prettier.config.js
       Skipping Procfile
       Removing file Procfile.adminpanel
       Removing file Procfile.api
       Removing file Procfile.identity
       Removing file Procfile.messaging
       Removing file Procfile.webhooks
       Removing file Procfile.workers
       Removing file README.md
       Removing directory scripts
       Removing directory server
       Removing file stylelint.config.js
       Removing directory terraform
       Removing file tsconfig.json
       Removing file yarn.lock
-----> Discovering process types
       Procfile declares types -> worker
-----> Compressing...
       Done: 54.2M
```